### PR TITLE
More readable gnuplot rendering and measurement accuracy improvements

### DIFF
--- a/c2clat.cpp
+++ b/c2clat.cpp
@@ -141,7 +141,7 @@ int main(int argc, char *argv[]) {
   if (plot) {
     std::cout << "EOD\n"
               << "plot '$data' matrix rowheaders columnheaders using 2:1:3 "
-                 "with image\n";
+                 "notitle with image\n";
   }
 
   return 0;

--- a/c2clat.cpp
+++ b/c2clat.cpp
@@ -140,6 +140,13 @@ int main(int argc, char *argv[]) {
 
   if (plot) {
     std::cout << "EOD\n"
+              << "set palette defined (0 '#80e0e0', 1 '#54e0eb', "
+                 "2 '#34d4f3', 3 '#26baf9', 4 '#40a0ff', 5 '#5888e7', "
+                 "6 '#6e72d1', 7 '#845cbb', 8 '#9848a7', 9 '#ac3493', "
+                 "10 '#c0207f', 11 '#d20e6d', 12 '#e60059', 13 '#f80047', "
+                 "14 '#ff0035', 15 '#ff0625', 16 '#ff2113', 17 '#ff3903', "
+                 "18 '#ff5400', 19 '#ff6c00', 20 '#ff8400', 21 '#ff9c00', "
+                 "22 '#ffb400', 23 '#ffcc00', 24 '#ffe400', 25 '#fffc00')\n"
               << "plot '$data' matrix rowheaders columnheaders using 2:1:3 "
                  "notitle with image, "
                  "'$data' matrix rowheaders columnheaders using "

--- a/c2clat.cpp
+++ b/c2clat.cpp
@@ -155,10 +155,11 @@ int main(int argc, char *argv[]) {
                  "14 '#ff0035', 15 '#ff0625', 16 '#ff2113', 17 '#ff3903', "
                  "18 '#ff5400', 19 '#ff6c00', 20 '#ff8400', 21 '#ff9c00', "
                  "22 '#ffb400', 23 '#ffcc00', 24 '#ffe400', 25 '#fffc00')\n"
+              << "#set tics font \",7\"\n"
               << "plot '$data' matrix rowheaders columnheaders using 2:1:3 "
                  "notitle with image, "
                  "'$data' matrix rowheaders columnheaders using "
-                 "2:1:(sprintf(\"%g\",$3)) notitle with labels\n";
+                 "2:1:(sprintf(\"%g\",$3)) notitle with labels #font \",5\"\n";
   }
 
   return 0;

--- a/c2clat.cpp
+++ b/c2clat.cpp
@@ -37,10 +37,14 @@ int main(int argc, char *argv[]) {
   int nsamples = 1000;
   bool plot = false;
   bool smt = false;
+  const char *name = NULL;
 
   int opt;
-  while ((opt = getopt(argc, argv, "ps:t")) != -1) {
+  while ((opt = getopt(argc, argv, "n:ps:t")) != -1) {
     switch (opt) {
+    case 'n':
+      name = optarg;
+      break;
     case 'p':
       plot = true;
       break;
@@ -58,8 +62,9 @@ int main(int argc, char *argv[]) {
   if (optind != argc) {
   usage:
     std::cerr << "c2clat 1.0.0 © 2020 Erik Rigtorp <erik@rigtorp.se>\n"
-                 "usage: c2clat [-p] [-t] [-s number_of_samples]\n"
+                 "usage: c2clat [-p] [-t] [-n name] [-s number_of_samples]\n"
                  "Use -t to interleave hardware threads with cores.\n"
+                 "The name passed using -n appears in the graph's title.\n"
                  "\nPlot results using gnuplot:\n"
                  "c2clat -p | gnuplot -p\n";
     exit(1);
@@ -123,7 +128,8 @@ int main(int argc, char *argv[]) {
 
   if (plot) {
     std::cout
-        << "set title \"Inter-core one-way data latency between CPU cores\"\n"
+        << "set title \"" << (name ? name : "") << (name ? " : " : "")
+        << "Inter-core one-way data latency between CPU cores\"\n"
         << "set xlabel \"CPU\"\n"
         << "set ylabel \"CPU\"\n"
         << "set cblabel \"Latency (ns)\"\n"

--- a/c2clat.cpp
+++ b/c2clat.cpp
@@ -141,7 +141,9 @@ int main(int argc, char *argv[]) {
   if (plot) {
     std::cout << "EOD\n"
               << "plot '$data' matrix rowheaders columnheaders using 2:1:3 "
-                 "notitle with image\n";
+                 "notitle with image, "
+                 "'$data' matrix rowheaders columnheaders using "
+                 "2:1:(sprintf(\"%g\",$3)) notitle with labels\n";
   }
 
   return 0;


### PR DESCRIPTION
Hello,

as part of another project consisting in measuring various atomic ops latency (https://github.com/wtarreau/atomic-tests), I wrote an ugly script that measures the C2C latency by iterating over the tool for each pair of cores. It's pretty slow because it restarts the full test for each combination, and I never devoted time to refine it. A coworker just pointed me to your project which is clearly focused on producting this matrix, and as such is much faster.

However I was missing a few things that I added:
  - more distinguishable colors in gnuplot, allowing to spot smaller differences (thanks BTW for showing how to use the "image" mode, I didn't know about it and was producing HTML instead)
  - values are printed by default (as they're the important part), and now they're readable on all colors
  - support interleaving threads with their cores, as nowadays most CPUs are enumerated with thread0 first on all cores, then thread1 on all cores. This gets lines and columns sorted by locality in a much more visible way.
  - added the ability to place a machine name on the gnuplot title (it started to be confusing when multiple gnuplots were open on one screen)
  - added an option to pre-heat the CPU core after pinning it to leave the time to CPU freq to react and reach full frequency and avoid wrong measurements when switching cores
  - also add a measurement of round-trips using compare-and-swap that more closely matches what locks use and the possible fairness issues that can happen there.

I'm attaching below examples of outputs on a Ryzen7-2700X and a Xeon-W2145 of similar generation, both 8-cores, which clearly shows the differences in L3 behavior (AMD prefers it fast but short distance while intel prefers a unified but slower one).

![xeon-w2145](https://user-images.githubusercontent.com/8141789/209565122-2f5c3542-f7e9-44e6-9e15-c686d6d63429.png)
![ryzen-2700x](https://user-images.githubusercontent.com/8141789/209565126-40543f7b-8f25-4cc8-bd55-6b84565865a6.png)

A more modern AMD EPYC 74F3 (24-cores, 4 GHz) clearly shows the 8 distinct chiplets between which the latency is horrible, and inside which it's pretty good. It also reveals that they're connected as a torus with diagonal links, as non-adjacent and non-diagonal transfers are the worst ones. Note that the output gnuplot script contains commented out directives to ease showing large outputs by shrinking font size.

![epyc-74f3](https://user-images.githubusercontent.com/8141789/209565336-b2a410f0-6f77-4bd7-9471-fdbc5c8ba27c.png)

I hope you'll be interested, as these are minor changes, which would permit me to switch to using your tool by default.